### PR TITLE
docs: fix simple typo, implicitely -> implicitly

### DIFF
--- a/Dump/Src/AceFilter/AceFilterCore/PluginApi.c
+++ b/Dump/Src/AceFilter/AceFilterCore/PluginApi.c
@@ -11,7 +11,7 @@
 #pragma warning(disable:4232)
 PLUGIN_API_TABLE const gc_PluginApiTable = {
 	.Common = {
-		.Log = Log, // Do not use directly (use the LOG() macro implicitely using this instead)
+		.Log = Log, // Do not use directly (use the LOG() macro implicitly using this instead)
 		.GetPluginOption = GetPluginOption,
 		.ConvertStrGuidToGuid = ConvertStrGuidToGuid,
 		.StrNextToken = StrNextToken,

--- a/Dump/Src/AceFilter/AceFilterCore/PluginCommon.h
+++ b/Dump/Src/AceFilter/AceFilterCore/PluginCommon.h
@@ -19,7 +19,7 @@
 
 /* --- DEFINES -------------------------------------------------------------- */
 #undef LOG_NO_NL
-// This new LOG macro implicitely uses the plugin-api-table (must be named "table"), and the plugin keyword (must be named "PLUGIN_KEYWORD")
+// This new LOG macro implicitly uses the plugin-api-table (must be named "table"), and the plugin keyword (must be named "PLUGIN_KEYWORD")
 #define LOG_NO_NL(lvl, frmt, ...)   api->Common.Log(lvl, LOG_CHR(lvl) ## SUB_LOG(LOG_KEYW() ## frmt), __VA_ARGS__);
 #define LOG_KEYW()                  _T("[") ## NONE(PLUGIN_KEYWORD) ## _T("] ")
 #define API_LOG                     LOG

--- a/Dump/Src/AceFilter/AceFilterPlugins/Importers/Sysvol/Sysvol.c
+++ b/Dump/Src/AceFilter/AceFilterPlugins/Importers/Sysvol/Sysvol.c
@@ -278,7 +278,7 @@ BOOL PLUGIN_GENERIC_INITIALIZE(
 	if (API_FAILED(bResult)) {
 		return ERROR_VALUE;
 	}
-    // Backup priv is implicitely used by FindFirst/NextFile
+    // Backup priv is implicitly used by FindFirst/NextFile
     gs_UseBackupPriv = api->Common.GetPluginOption(_T("usebackpriv"), FALSE) != NULL ? TRUE : FALSE;
     API_LOG(Info, _T("Accessing sysvol %s backup privilege"), gs_UseBackupPriv ? _T("using") : _T("not using"));
     if (gs_UseBackupPriv) {


### PR DESCRIPTION
There is a small typo in Dump/Src/AceFilter/AceFilterCore/PluginApi.c, Dump/Src/AceFilter/AceFilterCore/PluginCommon.h, Dump/Src/AceFilter/AceFilterPlugins/Importers/Sysvol/Sysvol.c.

Should read `implicitly` rather than `implicitely`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md